### PR TITLE
Add: prettier / prettier tw plugin

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+    "plugins": ["prettier-plugin-tailwindcss"],
+    "tailwindConfig": "./apps/web/tailwind.config.ts",
+    "semi": true,
+    "singleQuote": false,
+    "jsxSingleQuote": false,
+    "printWidth": 80,
+    "tabWidth": 4,
+    "useTabs": true
+  }

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -24,23 +24,32 @@ export default async function Page() {
 
 	return (
 		<main className="w-screen">
-			<div className="max-w-5xl mx-auto min-h-screen pt-40">
+			<div className="mx-auto min-h-screen max-w-5xl pt-40">
 				<div className="grid grid-cols-2">
 					<div>
-						<h1 className="font-black text-5xl">Registration</h1>
+						<h1 className="text-5xl font-black">Registration</h1>
 						<p className="mt-5 font-medium">
-							<span className="font-bold">Welcome!</span> Please fill out the form
-							below to complete your registration.
+							<span className="font-bold">Welcome!</span> Please
+							fill out the form below to complete your
+							registration.
 						</p>
 					</div>
-					<div className="bg-primary rounded-lg text-white flex flex-col items-center justify-center gap-y-3">
-						<p className="text-sm font-bold">Had a portal (abc123 & email) account?</p>
+					<div className="flex flex-col items-center justify-center gap-y-3 rounded-lg bg-primary text-white">
+						<p className="text-sm font-bold">
+							Had a portal (abc123 & email) account?
+						</p>
 						<Link href="/onboarding/migrate">
-							<Button className="w-full dark">Migrate from Portal</Button>
+							<Button className="dark w-full">
+								Migrate from Portal
+							</Button>
 						</Link>
 					</div>
 				</div>
-				<RegisterForm defaultEmail={clerkUser.emailAddresses[0]?.emailAddress || ""} />
+				<RegisterForm
+					defaultEmail={
+						clerkUser.emailAddresses[0]?.emailAddress || ""
+					}
+				/>
 			</div>
 		</main>
 	);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "prettier": "^3.2.5",
+    "prettier-plugin-tailwindcss": "^0.5.14",
     "turbo": "latest"
   },
   "packageManager": "pnpm@8.9.0",

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -57,9 +57,12 @@ export const eventCategories = pgTable("event_categories", {
 	color: text("color").notNull(),
 });
 
-export const eventCategoriesRelations = relations(eventCategories, ({ many }) => ({
-	eventsToCategories: many(eventsToCategories),
-}));
+export const eventCategoriesRelations = relations(
+	eventCategories,
+	({ many }) => ({
+		eventsToCategories: many(eventsToCategories),
+	}),
+);
 
 export const events = pgTable("events", {
 	id: text("id").primaryKey(),
@@ -88,16 +91,19 @@ export const eventsToCategories = pgTable("events_to_categories", {
 		.references(() => eventCategories.id),
 });
 
-export const eventsToCategoriesRelations = relations(eventsToCategories, ({ one }) => ({
-	category: one(eventCategories, {
-		fields: [eventsToCategories.categoryID],
-		references: [eventCategories.id],
+export const eventsToCategoriesRelations = relations(
+	eventsToCategories,
+	({ one }) => ({
+		category: one(eventCategories, {
+			fields: [eventsToCategories.categoryID],
+			references: [eventCategories.id],
+		}),
+		event: one(events, {
+			fields: [eventsToCategories.eventID],
+			references: [events.id],
+		}),
 	}),
-	event: one(events, {
-		fields: [eventsToCategories.eventID],
-		references: [events.id],
-	}),
-}));
+);
 
 export const checkins = pgTable(
 	"checkins",
@@ -111,7 +117,7 @@ export const checkins = pgTable(
 		return {
 			id: primaryKey({ columns: [table.eventID, table.userID] }),
 		};
-	}
+	},
 );
 
 export const checkinRelations = relations(checkins, ({ one }) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
+      prettier-plugin-tailwindcss:
+        specifier: ^0.5.14
+        version: 0.5.14(prettier@3.2.5)
       turbo:
         specifier: latest
         version: 1.12.5
@@ -4616,6 +4619,61 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
     dev: false
+
+  /prettier-plugin-tailwindcss@0.5.14(prettier@3.2.5):
+    resolution: {integrity: sha512-Puaz+wPUAhFp8Lo9HuciYKM2Y2XExESjeT+9NQoVFXZsPPnc9VYss2SpxdQ6vbatmt8/4+SN0oe0I1cPDABg9Q==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig-melody': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig-melody':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+    dependencies:
+      prettier: 3.2.5
+    dev: true
 
   /prettier@3.2.5:
     resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}


### PR DESCRIPTION
Adds prettier and the [prettier tailwind config](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier). Closes https://linear.app/acmutsa/issue/CK-32/setup-prettier-config.