### PR TITLE
View all checkins for an event

### DIFF
--- a/apps/web/src/app/admin/events/[id]/checkins/loading.tsx
+++ b/apps/web/src/app/admin/events/[id]/checkins/loading.tsx
@@ -1,0 +1,5 @@
+export default function EventCheckinsPage() {
+	return (
+		<div className="">Loading checkins for requested event. One sec...</div>
+	);
+}

--- a/apps/web/src/app/admin/events/[id]/checkins/page.tsx
+++ b/apps/web/src/app/admin/events/[id]/checkins/page.tsx
@@ -1,0 +1,64 @@
+import type { IDParamProp } from "@/lib/types/shared";
+import { getCheckinLog } from "@/lib/queries/checkins";
+import { getEventList } from "@/lib/queries/events";
+import { Suspense } from "react";
+import { UserRoundPlus } from "lucide-react";
+import AddCheckinDialogue from "@/components/dash/shared/AddCheckinDialogue";
+import CheckinsStatsSheet from "@/components/dash/shared/CheckinStatsSheet";
+import { Button } from "@/components/ui/button";
+import AdminCheckinLog from "@/components/dash/shared/AdminCheckinLog";
+import { Dialog, DialogTrigger } from "@/components/ui/dialog";
+import { getEventById } from "@/lib/queries/events";
+import { notFound } from "next/navigation";
+import EventCheckinsLog from "@/components/dash/admin/events/EventCheckinsLog";
+export default async function EventCheckinsPage({
+	params: { id },
+}: IDParamProp) {
+	const event = await getEventById(id);
+	if (!event) {
+		return notFound();
+	}
+	const eventList = [
+		{
+			id: event.id,
+			name: event.name,
+		},
+	];
+
+	return (
+		<div className="mx-auto max-w-6xl pt-4 text-foreground">
+			<div className="mb-5 grid grid-cols-2 px-5">
+				<h1 className="font-foreground text-3xl font-bold tracking-tight">
+					{`Checkins for ${event.name}`}
+				</h1>
+			</div>
+			<div className="mx-5 flex items-center justify-between rounded-lg border p-2">
+				<Suspense
+					fallback={<div>Grabbing checkin stats. One sec...</div>}
+				>
+					<CheckinsStatsSheet eventID={id} />
+				</Suspense>
+				<div>
+					<Dialog>
+						<DialogTrigger asChild>
+							<Button className="flex flex-nowrap gap-x-2">
+								<UserRoundPlus />
+								Add Checkin
+							</Button>
+						</DialogTrigger>
+						<AddCheckinDialogue eventList={eventList} />
+					</Dialog>
+				</div>
+			</div>
+			<div className="rounded-xl p-5">
+				<div>
+					<Suspense
+						fallback={<div>Grabbing checkin log. One sec...</div>}
+					>
+						<EventCheckinsLog eventID={id} eventName={event.name} />
+					</Suspense>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/app/admin/events/columns.tsx
+++ b/apps/web/src/app/admin/events/columns.tsx
@@ -157,7 +157,15 @@ export const columns: ColumnDef<EventWithCheckins>[] = [
 									href={`/events/${data.id}`}
 									className="h-full w-full"
 								>
-									View
+									View Details
+								</Link>
+							</DropdownMenuItem>
+							<DropdownMenuItem>
+								<Link
+									href={`/admin/events/${data.id}/checkins`}
+									className="h-full w-full"
+								>
+									View Checkins
 								</Link>
 							</DropdownMenuItem>
 							<DropdownMenuItem>

--- a/apps/web/src/app/admin/events/page.tsx
+++ b/apps/web/src/app/admin/events/page.tsx
@@ -7,7 +7,6 @@ import { columns } from "./columns";
 import { DataTable } from "@/components/ui/data-table";
 import EventStatsSheet from "@/components/dash/admin/events/EventStatsSheet";
 import { Button } from "@/components/ui/button";
-import AdminCheckinLog from "@/components/dash/shared/AdminCheckinLog";
 import { unstable_noStore as noStore } from "next/cache";
 
 async function Page() {
@@ -39,8 +38,9 @@ async function Page() {
 				<DataTable
 					columns={columns}
 					data={events}
-					tableName="events"
-					viewRoute={undefined}
+					options={{
+						tableName: "events",
+					}}
 				/>
 			</div>
 		</div>

--- a/apps/web/src/app/admin/members/page.tsx
+++ b/apps/web/src/app/admin/members/page.tsx
@@ -19,13 +19,13 @@ async function Page() {
 					<MemberStatsSheet />
 				</Suspense>
 			</div>
-			{/* <div className="border-muted">{events?.[0].name}</div> */}
 			<div className="rounded-xl p-5">
 				<DataTable
 					columns={columns}
 					data={members}
-					tableName="members"
-					// viewRoute="/member/"
+					options={{
+						tableName: "members",
+					}}
 				/>
 			</div>
 		</div>

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,13 +1,20 @@
 import Link from "next/link";
 
-// TODO: make this look better
-
 export default function NotFound() {
 	return (
-		<div>
-			<h2>Not Found</h2>
-			<p>Could not find requested resource</p>
-			<Link href="/">Return Home</Link>
+		<div className="flex h-screen w-screen items-center justify-center bg-white dark:bg-black">
+			<div className="text-center">
+				<h1 className="text-hackathon mb-4 text-9xl font-extrabold dark:text-primary">
+					404
+				</h1>
+				<h2 className="mb-4 text-4xl font-bold">Page Not Found</h2>
+				<p className="mb-8 text-lg">
+					The page you are looking for does not exist.
+				</p>
+				<Link href="/" className="text-lg text-blue-500 underline">
+					Return to Home
+				</Link>
+			</div>
 		</div>
 	);
 }

--- a/apps/web/src/components/dash/admin/categories/CategoryView.tsx
+++ b/apps/web/src/components/dash/admin/categories/CategoryView.tsx
@@ -25,7 +25,9 @@ export default async function AdminCategoryView() {
 				<DataTable
 					data={categories}
 					columns={eventCategoryColumns}
-					tableName="categories"
+					options={{
+						tableName: "categories",
+					}}
 				/>
 			</div>
 		</>

--- a/apps/web/src/components/dash/admin/events/EventCheckinsColumns.tsx
+++ b/apps/web/src/components/dash/admin/events/EventCheckinsColumns.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { ColumnDef, Row } from "@tanstack/react-table";
+import { DataTableColumnHeader } from "@/components/ui/data-table";
+import { formatDate } from "date-fns";
+
+const timeFormatString = "eee, MMM dd yyyy HH:mm bb";
+
+type EventCheckinEntry = {
+	time: Date;
+	feedback: string | null;
+	author: {
+		userID: number;
+		firstName: string;
+		lastName: string;
+	};
+	rating: number | null;
+};
+
+const timeCell = ({ row }: { row: Row<EventCheckinEntry> }) => {
+	const formattedDate = formatDate(row.getValue("time"), timeFormatString);
+	return <div>{formattedDate}</div>;
+};
+
+export const eventCheckinColumns: ColumnDef<EventCheckinEntry>[] = [
+	{
+		accessorKey: "author.userID",
+		header: ({ column }) => {
+			return <DataTableColumnHeader column={column} title="User ID" />;
+		},
+
+		enableSorting: true,
+	},
+	{
+		id: "author",
+		accessorFn: (row) => `${row.author.firstName} ${row.author.lastName}`,
+		header: ({ column }) => {
+			return <DataTableColumnHeader column={column} title="Name" />;
+		},
+		cell: ({ row }) => {
+			return (
+				<div>
+					{row.original.author.firstName}{" "}
+					{row.original.author.lastName}
+				</div>
+			);
+		},
+		enableSorting: true,
+	},
+	{
+		accessorKey: "time",
+		header: ({ column }) => {
+			return <DataTableColumnHeader column={column} title="Time" />;
+		},
+		cell: timeCell,
+		enableSorting: true,
+	},
+	{
+		accessorKey: "rating",
+		id: "rating",
+		header: ({ column }) => {
+			return <DataTableColumnHeader column={column} title="Rating" />;
+		},
+		cell: ({ row }) => {
+			return (
+				<div>
+					<p>{row.getValue("rating") ?? "unrated"}</p>
+				</div>
+			);
+		},
+	},
+	{
+		accessorKey: "feedback",
+		header: ({ column }) => {
+			return <DataTableColumnHeader column={column} title="Feedback" />;
+		},
+		cell: ({ row }) => {
+			return (
+				<div>
+					<p>{row.getValue("feedback") ?? ""}</p>
+				</div>
+			);
+		},
+		enableSorting: true,
+	},
+];

--- a/apps/web/src/components/dash/admin/events/EventCheckinsLog.tsx
+++ b/apps/web/src/components/dash/admin/events/EventCheckinsLog.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { getCheckinLog } from "@/lib/queries/checkins";
+import { DataTable } from "@/components/ui/data-table";
+import { eventCheckinColumns } from "./EventCheckinsColumns";
+import Link from "next/link";
+export default async function EventCheckinsLog({
+	eventID,
+	eventName,
+}: {
+	eventID: string;
+	eventName: string;
+}) {
+	const data = await getCheckinLog(eventID);
+	return (
+		<div>
+			<div>
+				<DataTable
+					data={data}
+					columns={eventCheckinColumns}
+					options={{
+						tableName: "event checkins",
+						downloadRoute: `/api/admin/export?name=${"event checkins"}&event_id=${eventID}`,
+					}}
+				/>
+				<Link href="/admin/events">
+					<p className="w-full pt-10 text-end text-sm underline">
+						Back to Events
+					</p>
+				</Link>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/dash/admin/semesters/SemesterView.tsx
+++ b/apps/web/src/components/dash/admin/semesters/SemesterView.tsx
@@ -25,7 +25,9 @@ export default async function AdminSemesterView() {
 				<DataTable
 					data={semesters}
 					columns={semesterColumns}
-					tableName="semesters"
+					options={{
+						tableName: "semesters",
+					}}
 				/>
 			</div>
 		</>

--- a/apps/web/src/components/dash/shared/AdminCheckinLog.tsx
+++ b/apps/web/src/components/dash/shared/AdminCheckinLog.tsx
@@ -3,9 +3,7 @@ import { getCheckinLog } from "@/lib/queries/checkins";
 import { DataTable } from "@/components/ui/data-table";
 import { checkinLogColumns } from "./CheckinLogColumns";
 
-type Props = {};
-
-async function AdminCheckinLog({}: Props) {
+async function AdminCheckinLog() {
 	const data = await getCheckinLog();
 	return (
 		<div>
@@ -13,7 +11,9 @@ async function AdminCheckinLog({}: Props) {
 				<DataTable
 					data={data}
 					columns={checkinLogColumns}
-					tableName="checkins"
+					options={{
+						tableName: "all checkins",
+					}}
 				/>
 			</div>
 		</div>

--- a/apps/web/src/components/dash/shared/CheckinLogColumns.tsx
+++ b/apps/web/src/components/dash/shared/CheckinLogColumns.tsx
@@ -1,18 +1,6 @@
 "use client";
 
 import { ColumnDef, Row } from "@tanstack/react-table";
-import Image from "next/image";
-import Link from "next/link";
-import { MoreHorizontal, ArrowUpDown } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuLabel,
-	DropdownMenuSeparator,
-	DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { DataTableColumnHeader } from "@/components/ui/data-table";
 import { formatDate } from "date-fns";
 

--- a/apps/web/src/components/dash/shared/CheckinStatsSheet.tsx
+++ b/apps/web/src/components/dash/shared/CheckinStatsSheet.tsx
@@ -2,10 +2,8 @@ import React from "react";
 import { Separator } from "@/components/ui/separator";
 import { getCheckinStatsOverview } from "@/lib/queries/checkins";
 
-type Props = {};
-
-async function CheckinStatsSheet({}: Props) {
-	const stats = await getCheckinStatsOverview();
+async function CheckinStatsSheet({ eventID }: { eventID?: string }) {
+	const stats = await getCheckinStatsOverview(eventID);
 	return (
 		<div className="flex w-fit space-x-4">
 			<div className="flex flex-col p-1">
@@ -16,20 +14,6 @@ async function CheckinStatsSheet({}: Props) {
 					{stats.total_checkins}
 				</span>
 			</div>
-			{/* <Separator orientation="vertical" />
-			<div className="flex flex-col p-1">
-				<span className="text-xs text-muted-foreground">This Week</span>
-				<span className="text-lg font-semibold">{stats.thisWeek}</span>
-			</div>
-			<Separator orientation="vertical" />
-			<div className="flex flex-col p-1">
-				<span className="text-xs text-muted-foreground">
-					Past Events
-				</span>
-				<span className="text-lg font-semibold">
-					{stats.pastEvents}
-				</span>
-			</div> */}
 		</div>
 	);
 }

--- a/apps/web/src/lib/queries/checkins.ts
+++ b/apps/web/src/lib/queries/checkins.ts
@@ -2,7 +2,7 @@ import { count, db, eq, inArray, sql } from "db";
 import { checkins } from "db/schema";
 import { CheckInUserClientProps } from "db/types";
 
-export const getCheckinLog = async () => {
+export const getCheckinLog = async (eventID?: string) => {
 	return await db.query.checkins.findMany({
 		columns: {
 			time: true,
@@ -23,11 +23,15 @@ export const getCheckinLog = async () => {
 				},
 			},
 		},
+		where: eventID != null ? eq(checkins.eventID, eventID) : undefined,
 	});
 };
 
-export const getCheckinStatsOverview = async () => {
-	const [res] = await db.select({ total_checkins: count() }).from(checkins);
+export const getCheckinStatsOverview = async (eventID?: string) => {
+	const [res] = await db
+		.select({ total_checkins: count() })
+		.from(checkins)
+		.where(eventID != null ? eq(checkins.eventID, eventID) : undefined);
 	return res;
 };
 

--- a/apps/web/src/lib/types/shared.ts
+++ b/apps/web/src/lib/types/shared.ts
@@ -3,10 +3,11 @@ export type SearchParams = { [key: string]: string | undefined };
 export type IDParamProp = { params: { id: string } };
 export type ExportNames =
 	| "events"
-	| "checkins"
+	| "all checkins"
 	| "members"
 	| "semesters"
-	| "categories";
+	| "categories"
+	| "event checkins";
 
 export type MajorType = (typeof majors)[number];
 export type ClassificationType =


### PR DESCRIPTION
## Why
The way we currently have this implemented is by one big checking table which will get hectic once we have more issues. When admins want to view checkins and feedback for a single event, it is not super easy to do.

## What 
Added a "View Checkins" option for the events table. In the future, it would be nice to have metrics on the type of users who checked in to the events. 


## Satisfies 
#129 
https://linear.app/acmutsa/issue/CK-137/add-ability-to-view-all-checkins-for-an-event