### PR TITLE
153 fix sign in redirects in clubkit

### DIFF
--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -25,7 +25,7 @@ export default async function AdminLayout({
 		where: eq(users.clerkID, userId),
 	});
 
-	if (!user){
+	if (!user) {
 		return redirect("/onboarding");
 	}
 

--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -8,6 +8,7 @@ import Navbar from "@/components/shared/navbar";
 import DashNavItem from "@/components/dash/shared/DashNavItem";
 import ClientToast from "@/components/shared/client-toast";
 import c from "config";
+import { ADMIN_ROLES } from "@/lib/constants";
 
 export default async function AdminLayout({
 	children,
@@ -24,7 +25,11 @@ export default async function AdminLayout({
 		where: eq(users.clerkID, userId),
 	});
 
-	if (!user || (user.role !== "admin" && user.role !== "super_admin")) {
+	if (!user){
+		return redirect("/onboarding");
+	}
+
+	if (!ADMIN_ROLES.includes(user.role)) {
 		console.log("Denying admin access to user", user);
 		return (
 			<FullScreenMessage

--- a/apps/web/src/app/onboarding/layout.tsx
+++ b/apps/web/src/app/onboarding/layout.tsx
@@ -10,7 +10,6 @@ export default async function OnboardingLayout({
 }: {
 	children: React.ReactNode;
 }) {
-	// TODO: protect stuffs from re-registration
 
 	const { userId } = await auth();
 

--- a/apps/web/src/app/onboarding/layout.tsx
+++ b/apps/web/src/app/onboarding/layout.tsx
@@ -10,7 +10,6 @@ export default async function OnboardingLayout({
 }: {
 	children: React.ReactNode;
 }) {
-
 	const { userId } = await auth();
 
 	if (!userId) return redirect("/sign-up");

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Navbar from "@/components/shared/navbar";
+import Link from "next/link";
 export default function Home() {
 	return (
 		// bg-[var(--my-var,var(--my-background,pink))]
@@ -6,8 +7,11 @@ export default function Home() {
 			<header>
 				<Navbar showBorder />
 			</header>
-			<main className="flex w-full flex-1 items-center justify-center">
+			<main className="flex w-full flex-1 flex-col items-center justify-center space-y-5">
 				<h1 className="text-4xl font-black">ClubKit</h1>
+				<Link href="/events" className="h-min p-2 underline">
+					<p>Find Events →</p>
+				</Link>
 			</main>
 		</div>
 	);

--- a/apps/web/src/components/shared/navbar.tsx
+++ b/apps/web/src/components/shared/navbar.tsx
@@ -69,7 +69,9 @@ export default async function Navbar({ siteRegion, showBorder }: NavbarProps) {
 					<>
 						<Link
 							href={
-								hasCompletedRegistration ? "/dash" : "/onboarding"
+								hasCompletedRegistration
+									? "/dash"
+									: "/onboarding"
 							}
 						>
 							<Button
@@ -84,31 +86,24 @@ export default async function Navbar({ siteRegion, showBorder }: NavbarProps) {
 									: "Complete Registration / Connect Account"}
 							</Button>
 						</Link>
-						
-						{
-							hasCompletedRegistration && (
-								ADMIN_ROLES.includes(user.role) && (
-									<Link href={"/admin"}>
-										<Button
-											variant={"outline"}
-											className="text-blue-400"
-										>
-											Admin
-										</Button>
-									</Link>
-							)
-						)}
+
+						{hasCompletedRegistration &&
+							ADMIN_ROLES.includes(user.role) && (
+								<Link href={"/admin"}>
+									<Button
+										variant={"outline"}
+										className="text-blue-400"
+									>
+										Admin
+									</Button>
+								</Link>
+							)}
 
 						<ProfileButton
 							clerkUser={clerkUser}
 							clerkAuth={clerkAuth}
 							user={user}
 						/>
-							
-						
-							
-							
-						
 					</>
 				) : (
 					<>
@@ -156,19 +151,22 @@ export default async function Navbar({ siteRegion, showBorder }: NavbarProps) {
 												? "ghost"
 												: "default"
 										}
-										className="whitespace-normal p-4 h-12"
+										className="h-12 whitespace-normal p-4"
 									>
 										{hasCompletedRegistration
 											? "Dashboard"
 											: "Complete Registration / Connect Account"}
 									</Button>
 								</Link>
-								
-								{ hasCompletedRegistration && ADMIN_ROLES.includes(user.role) && (
-									<Link href={"/admin"}>
-										<Button variant={"ghost"}>Admin</Button>
-									</Link>
-								)}
+
+								{hasCompletedRegistration &&
+									ADMIN_ROLES.includes(user.role) && (
+										<Link href={"/admin"}>
+											<Button variant={"ghost"}>
+												Admin
+											</Button>
+										</Link>
+									)}
 								<div className="px-4">
 									<ProfileButton
 										clerkUser={clerkUser}

--- a/apps/web/src/components/shared/navbar.tsx
+++ b/apps/web/src/components/shared/navbar.tsx
@@ -14,7 +14,7 @@ import {
 	SheetTitle,
 	SheetTrigger,
 } from "@/components/ui/sheet";
-
+import { ADMIN_ROLES } from "@/lib/constants";
 import c from "config";
 import { Menu } from "lucide-react";
 
@@ -82,8 +82,7 @@ export default async function Navbar({ siteRegion, showBorder }: NavbarProps) {
 						<Link href={"/events"}>
 							<Button variant={"outline"}>Events</Button>
 						</Link>
-						{(user.role === "admin" ||
-							user.role === "super_admin") && (
+						{ADMIN_ROLES.includes(user.role) && (
 							<Link href={"/admin"}>
 								<Button
 									variant={"outline"}
@@ -154,8 +153,7 @@ export default async function Navbar({ siteRegion, showBorder }: NavbarProps) {
 								<Link href={"/events"}>
 									<Button variant={"ghost"}>Events</Button>
 								</Link>
-								{(user.role === "admin" ||
-									user.role === "super_admin") && (
+								{ADMIN_ROLES.includes(user.role) && (
 									<Link href={"/admin"}>
 										<Button variant={"ghost"}>Admin</Button>
 									</Link>

--- a/apps/web/src/components/shared/navbar.tsx
+++ b/apps/web/src/components/shared/navbar.tsx
@@ -83,7 +83,7 @@ export default async function Navbar({ siteRegion, showBorder }: NavbarProps) {
 							>
 								{hasCompletedRegistration
 									? "Dashboard"
-									: "Complete Registration / Connect Account"}
+									: "Complete Registration"}
 							</Button>
 						</Link>
 
@@ -155,7 +155,7 @@ export default async function Navbar({ siteRegion, showBorder }: NavbarProps) {
 									>
 										{hasCompletedRegistration
 											? "Dashboard"
-											: "Complete Registration / Connect Account"}
+											: "Complete Registration"}
 									</Button>
 								</Link>
 

--- a/apps/web/src/components/shared/navbar.tsx
+++ b/apps/web/src/components/shared/navbar.tsx
@@ -17,6 +17,7 @@ import {
 import { ADMIN_ROLES } from "@/lib/constants";
 import c from "config";
 import { Menu } from "lucide-react";
+import { SignOutButton } from "@clerk/nextjs";
 
 type NavbarProps = {
 	siteRegion?: string;
@@ -33,8 +34,8 @@ export default async function Navbar({ siteRegion, showBorder }: NavbarProps) {
 				with: { data: true },
 			})
 		: null;
-
-	const registrationComplete = user != null;
+	const hasSignedIn = userId != null;
+	const hasCompletedRegistration = user != null;
 	return (
 		<div
 			className={
@@ -64,39 +65,50 @@ export default async function Navbar({ siteRegion, showBorder }: NavbarProps) {
 
 			{/* Large screen navbar */}
 			<div className="my-2 hidden items-center justify-end gap-x-2 md:flex">
-				{user ? (
+				{hasSignedIn ? (
 					<>
 						<Link
-							href={registrationComplete ? "/dash" : "/sign-up"}
+							href={
+								hasCompletedRegistration ? "/dash" : "/onboarding"
+							}
 						>
 							<Button
 								variant={
-									registrationComplete ? "outline" : "default"
+									hasCompletedRegistration
+										? "outline"
+										: "default"
 								}
 							>
-								{registrationComplete
+								{hasCompletedRegistration
 									? "Dashboard"
-									: "Complete Registration"}
+									: "Complete Registration / Connect Account"}
 							</Button>
 						</Link>
-						<Link href={"/events"}>
-							<Button variant={"outline"}>Events</Button>
-						</Link>
-						{ADMIN_ROLES.includes(user.role) && (
-							<Link href={"/admin"}>
-								<Button
-									variant={"outline"}
-									className="text-blue-400"
-								>
-									Admin
-								</Button>
-							</Link>
+						
+						{
+							hasCompletedRegistration && (
+								ADMIN_ROLES.includes(user.role) && (
+									<Link href={"/admin"}>
+										<Button
+											variant={"outline"}
+											className="text-blue-400"
+										>
+											Admin
+										</Button>
+									</Link>
+							)
 						)}
+
 						<ProfileButton
 							clerkUser={clerkUser}
 							clerkAuth={clerkAuth}
 							user={user}
 						/>
+							
+						
+							
+							
+						
 					</>
 				) : (
 					<>
@@ -122,9 +134,9 @@ export default async function Navbar({ siteRegion, showBorder }: NavbarProps) {
 						<Menu />
 					</SheetTrigger>
 					<SheetContent className="flex max-w-[40%] flex-col-reverse items-center justify-center gap-y-1">
-						{user ? (
+						{hasSignedIn ? (
 							<>
-								{registrationComplete && (
+								{hasCompletedRegistration && (
 									<Link href="/settings">
 										<Button variant="ghost">
 											Settings
@@ -133,27 +145,26 @@ export default async function Navbar({ siteRegion, showBorder }: NavbarProps) {
 								)}
 								<Link
 									href={
-										registrationComplete
+										hasCompletedRegistration
 											? "/dash"
 											: "/onboarding"
 									}
 								>
 									<Button
 										variant={
-											registrationComplete
+											hasCompletedRegistration
 												? "ghost"
 												: "default"
 										}
+										className="whitespace-normal p-4 h-12"
 									>
-										{registrationComplete
+										{hasCompletedRegistration
 											? "Dashboard"
-											: "Complete Registration"}
+											: "Complete Registration / Connect Account"}
 									</Button>
 								</Link>
-								<Link href={"/events"}>
-									<Button variant={"ghost"}>Events</Button>
-								</Link>
-								{ADMIN_ROLES.includes(user.role) && (
+								
+								{ hasCompletedRegistration && ADMIN_ROLES.includes(user.role) && (
 									<Link href={"/admin"}>
 										<Button variant={"ghost"}>Admin</Button>
 									</Link>

--- a/apps/web/src/components/shared/profile-button.tsx
+++ b/apps/web/src/components/shared/profile-button.tsx
@@ -5,7 +5,6 @@ import {
 	DropdownMenuItem,
 	DropdownMenuLabel,
 	DropdownMenuSeparator,
-	DropdownMenuShortcut,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -56,7 +55,7 @@ export default async function ProfileButton({
 						<DropdownSwitcher />
 						<Link href={`/onboarding`}>
 							<DropdownMenuItem className="cursor-pointer">
-								Complete Registration / Connect Account
+								Complete Registration
 							</DropdownMenuItem>
 						</Link>
 						<Link
@@ -104,7 +103,6 @@ export default async function ProfileButton({
 				<DropdownMenuSeparator />
 				<DropdownMenuGroup>
 					<DropdownSwitcher />
-
 					<Link href={`https://tally.so/r/wbKXN1`} target="_blank">
 						<DropdownMenuItem className="cursor-pointer">
 							Report a Bug

--- a/apps/web/src/components/shared/profile-button.tsx
+++ b/apps/web/src/components/shared/profile-button.tsx
@@ -56,7 +56,7 @@ export default async function ProfileButton({
 						<DropdownSwitcher />
 						<Link href={`/onboarding`}>
 							<DropdownMenuItem className="cursor-pointer">
-								Complete Registration
+								Complete Registration / Connect Account
 							</DropdownMenuItem>
 						</Link>
 						<Link

--- a/apps/web/src/lib/constants/index.ts
+++ b/apps/web/src/lib/constants/index.ts
@@ -3,3 +3,5 @@ export const TWENTY_FOUR_HOURS = 24;
 export const UNIQUE_KEY_CONSTRAINT_VIOLATION_CODE = "23505";
 export const LOWER_ALPHANUM_CUSTOM_ALPHABET =
 	"1234567890abcdefghijklmnopqrstuvwxyz";
+
+export const ADMIN_ROLES:Array<string> = ["admin", "super_admin"] as const;

--- a/apps/web/src/lib/constants/index.ts
+++ b/apps/web/src/lib/constants/index.ts
@@ -4,4 +4,4 @@ export const UNIQUE_KEY_CONSTRAINT_VIOLATION_CODE = "23505";
 export const LOWER_ALPHANUM_CUSTOM_ALPHABET =
 	"1234567890abcdefghijklmnopqrstuvwxyz";
 
-export const ADMIN_ROLES:Array<string> = ["admin", "super_admin"] as const;
+export const ADMIN_ROLES: Array<string> = ["admin", "super_admin"] as const;

--- a/apps/web/src/lib/queries/users.ts
+++ b/apps/web/src/lib/queries/users.ts
@@ -4,7 +4,7 @@ import { checkins, data, events, users } from "db/schema";
 import { getCurrentSemester } from "./semesters";
 import { ADMIN_ROLES } from "../constants";
 
-type UserRoles = typeof users.$inferSelect.role[]
+type UserRoles = (typeof users.$inferSelect.role)[];
 
 export const getAdminUser = async (clerkId: string) => {
 	return db.query.users.findFirst({

--- a/apps/web/src/lib/queries/users.ts
+++ b/apps/web/src/lib/queries/users.ts
@@ -2,13 +2,16 @@ import c from "config";
 import { count, db, eq, sum } from "db";
 import { checkins, data, events, users } from "db/schema";
 import { getCurrentSemester } from "./semesters";
+import { ADMIN_ROLES } from "../constants";
+
+type UserRoles = typeof users.$inferSelect.role[]
 
 export const getAdminUser = async (clerkId: string) => {
 	return db.query.users.findFirst({
 		where: (users, { eq, and, inArray }) =>
 			and(
 				eq(users.clerkID, clerkId),
-				inArray(users.role, ["admin", "super_admin"]),
+				inArray(users.role, ADMIN_ROLES as UserRoles),
 			),
 	});
 };

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,6 +1,7 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { getAdminUser } from "./lib/queries/users";
 import { NextResponse } from "next/server";
+
 const isProtectedRoute = createRouteMatcher([
 	"/dash(.*)",
 	"/admin(.*)",
@@ -8,12 +9,12 @@ const isProtectedRoute = createRouteMatcher([
 ]);
 const isAdminAPIRoute = createRouteMatcher(["/api/admin(.*)"]);
 
-// come back and check if this is valid
 export default clerkMiddleware(async (auth, req) => {
-	const { userId } = await auth();
-
-	if (isProtectedRoute(req)) {
-		await auth.protect();
+	const { userId, redirectToSignIn } = await auth();
+	if (isProtectedRoute(req) && !userId) {
+		redirectToSignIn({
+			returnBackUrl: req.nextUrl.toString(),
+		});
 	}
 
 	// protect admin api routes


### PR DESCRIPTION
## Why
Users would be redirected to their dashboard instead of the the protected route they wished to navigate to after signing in.

## What
- Added middleware logic to redirect unauthenticated users to sign-in and keep track of the desired route they wish to be directed to after signing in
- Allowed a user to sign out while in between signing in and onboarding
- Updated the UI to better reflect the change above by rendering a "complete registration" button instead of the normal `sign in` and `sign up` buttons

## Satisfies 
#153 

## NOTE
Environment variables for Clubkit have been modified, but `NEXT_PUBLIC_CLERK_SIGN_IN_FORCE_REDIRECT_URL` and `NEXT_PUBLIC_CLERK_SIGN_UP_FORCE_REDIRECT_URL` should be removed from local `.env` files and from Portal's environment variables.