### PR TITLE
Added logic to show blank screen before bringing user to Dashboard from sign-in

### DIFF
--- a/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,15 +1,24 @@
-// "use client"
-import { SignIn } from "@clerk/nextjs";
+"use client";
+import { SignIn, useAuth } from "@clerk/nextjs";
 import { Button } from "@/components/ui/button";
 import c from "config";
 import Link from "next/link";
 import PortalMigrationExplainer from "@/components/dash/shared/PortalMigrationExplainer";
+
 export default function Page() {
+	const {isLoaded } = useAuth();
+
+	if (!isLoaded) {
+		return (
+			<main className="flex h-screen w-screen items-center justify-center">
+			</main>
+		);
+	}
 	return (
 		<main className="flex h-screen w-screen flex-col items-center justify-center gap-y-5">
 			<div className="flex max-w-[400px] flex-col items-center justify-center gap-y-5">
 				<h1 className="text-4xl font-black">{c.clubName}</h1>
-				<SignIn />
+				<SignIn forceRedirectUrl="/dash" />
 				<Link href="/onboarding/migrate" className="w-full">
 					<Button className="w-full">
 						Migrate From Legacy Portal


### PR DESCRIPTION
Basically the reason that the migration screen flashes is that after pressing the sign in button with clerk it deletes that sign-in/sign-up terminal and just keeps the text Clubkit and "Migrate from legacy portal button".